### PR TITLE
Hex link/remove text

### DIFF
--- a/HexLink/HexLink.html
+++ b/HexLink/HexLink.html
@@ -28,6 +28,7 @@
   <div class="hex-container">
     <svg viewBox='0 20 300 260' height=auto>
       <a class="link">
+        <title id="title" />
         <defs>
           <clipPath id="hex-clip">
             <polygon id="shape" />

--- a/HexLink/HexLink.html
+++ b/HexLink/HexLink.html
@@ -5,21 +5,12 @@
   #background {
     fill: #931621;
   }
-  text {
-    visibility: hidden;
-  }
   .link:not([disabled]) {
     text-decoration: none;
     cursor: pointer;
   }
   .link:not([disabled]):focus #background, .link:not([disabled]):hover #background {
     fill: #FF934F;
-  }
-  .link:not([disabled]):focus image, .link:not([disabled]):hover image {
-    visibility: hidden;
-  }
-  .link:not([disabled]):focus text, .link:not([disabled]):hover text {
-    visibility: visible;
   }
   .hex-container {
     display: block;
@@ -39,7 +30,7 @@
       <a class="link">
         <defs>
           <clipPath id="hex-clip">
-            <polygon id="shape"/>
+            <polygon id="shape" />
           </clipPath>
         </defs>
         <rect id='background'
@@ -53,13 +44,6 @@
           x='50'
           y='50'
         />
-        <text id="text"
-          x=150
-          y=140
-          text-anchor='middle'
-          dominant-baseline='central'
-          style='font-size:2vmax;'>
-        </text>
       </a>
       </polygon>
     </svg>

--- a/HexLink/HexLink.js
+++ b/HexLink/HexLink.js
@@ -37,7 +37,7 @@
       else this.shadowRoot.querySelector('.link').setAttribute('disabled', true)
       this.shadowRoot.querySelector('#shape').setAttribute('points', points)
       if (name) {
-        this.shadowRoot.querySelector('#shape').innerHTML = `<title id='hex-label'>${name}</title>`
+        this.shadowRoot.querySelector('#title').innerHTML = name
       }
       if (svgFilePath) {
         this.shadowRoot.querySelector('image').setAttribute('href', svgFilePath)

--- a/HexLink/HexLink.js
+++ b/HexLink/HexLink.js
@@ -37,7 +37,6 @@
       else this.shadowRoot.querySelector('.link').setAttribute('disabled', true)
       this.shadowRoot.querySelector('#shape').setAttribute('points', points)
       if (name) {
-        this.shadowRoot.querySelector('#text').innerHTML = name
         this.shadowRoot.querySelector('#shape').innerHTML = `<title id='hex-label'>${name}</title>`
       }
       if (svgFilePath) {


### PR DESCRIPTION
Always show the hex icon rather than swapping to text on a hover. Use the name property as the title for the hex.