### PR TITLE
chore: allow crawling of assets

### DIFF
--- a/app/root/robots.txt
+++ b/app/root/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
-Disallow: /assets/
 Disallow: /version.json
+Disallow: /*/api


### PR DESCRIPTION
Twitter cards and google search results couldn't crawl the assets so can't display pictures.

Removed assets from the disallow list, added in api routes as I don't want those getting bombed by bots.