### PR TITLE
chore: lowercase description meta label

### DIFF
--- a/app/templates/components/base-page.njk
+++ b/app/templates/components/base-page.njk
@@ -27,7 +27,7 @@
     {% set about = about | default("Personal website of Alastair Smith.") %}
     {% set baseUrl = "https://alsmith.dev" %}
     {% set imageUrl = baseUrl + (imageUrl | default("/assets/images/logo.1000x1000.png")) %}
-    <meta name="Description" content="{{ about }}">
+    <meta name="description" content="{{ about }}">
     <meta name="author" content="Alastair Smith">
 
     <meta property="og:title" content="{{ pageTitle }}">


### PR DESCRIPTION
I don't think google was properly picking up the description meta field, so I made it use `description` instead of `Description` to see if that makes a difference