### PR TITLE
bugfix: remove any existing inline policies

### DIFF
--- a/infrastructure/modules/bort_endpoints/main.tf
+++ b/infrastructure/modules/bort_endpoints/main.tf
@@ -56,6 +56,8 @@ resource "aws_iam_role" "gateway_role" {
   name                 = local.name_prefix
   permissions_boundary = var.permissions_boundary
   tags                 = local.tags
+
+  inline_policy {}
 }
 
 data "aws_iam_policy_document" "gateway_permissions" {

--- a/infrastructure/modules/kelly_endpoint/main.tf
+++ b/infrastructure/modules/kelly_endpoint/main.tf
@@ -38,6 +38,8 @@ resource "aws_iam_role" "role" {
   name                 = local.name_prefix
   permissions_boundary = var.permissions_boundary
   tags                 = local.tags
+
+  inline_policy {}
 }
 
 resource "aws_iam_policy" "permissions" {

--- a/infrastructure/test/compliance/aws_iam_inline_policies.feature
+++ b/infrastructure/test/compliance/aws_iam_inline_policies.feature
@@ -2,6 +2,7 @@ Feature: AWS IAM Inline Policies
   In order to version and share access levels easier
   all AWS roles shall use managed policies instead of inline policies
 
-Scenario: All AWS IAM roles avoid inline policies
+Scenario: All AWS IAM roles disallow inline policies
   Given I have aws_iam_role defined
-  Then it must not contain inline_policy
+  Then it must contain inline_policy
+  And its value must be ""


### PR DESCRIPTION
compliance check was failing for existing empty inline policies
enforcing a value of {} for inline policies deletes any existing inline policies